### PR TITLE
Add `alloc` feature enabled by default with `std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,14 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Set up toolchain
       run: rustup show
-    - name: Test
+    - name: Test all features
       run: |
         cargo test --all-features --all-targets --workspace
+        cargo test --all-features --doc --workspace
+    - name: Test non-default features
+      run: |
         cargo test --no-default-features --all-targets --workspace
+        cargo test --no-default-features --features alloc --all-targets --workspace
   analyze:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["no-std", "value-formatting"]
 
 [features]
 default = ["std"]
-std = []
+alloc = []
+std = ["alloc"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ assert_eq!(*n, 12);
 assert_eq!(format!("{n}"), "12th");
 ```
 
+## Features
+
+* **std**: (default) all functionality enabled.
+* **alloc**: (default; enabled by **std**) all functionality enabled.
+
+This crate supports `no_std`, though functionality is limited. If you disable default features, `no_std` will be enabled.
+You can optionally add feature `alloc` (enabled by default with `std`) to enable all functionality without requiring `std`.
+
+```bash
+cargo add ordinal-trait --no-default-features --features alloc
+```
+
 ## Performance
 
 Compared to most other implementations that allocate a string just to check the last one or two characters, this implementation is much faster and does not allocate a string[^1].

--- a/docs/suffix_violin_plot.svg
+++ b/docs/suffix_violin_plot.svg
@@ -3,8 +3,8 @@
 text { fill: #000000 }
 polyline { fill: none; stroke: #000000 }
 @media (prefers-color-scheme: dark) {
-  text { fill: #ffffff!important }
-  polyline { fill: none; stroke: #ffffff!important }
+  text { fill: #ffffff }
+  polyline { fill: none; stroke: #ffffff }
 }
 ]]></style>
 <text x="480" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="16.129032258064516" opacity="1">

--- a/docs/suffix_violin_plot.svg
+++ b/docs/suffix_violin_plot.svg
@@ -3,8 +3,8 @@
 text { fill: #000000 }
 polyline { fill: none; stroke: #000000 }
 @media (prefers-color-scheme: dark) {
-  text { fill: #ffffff }
-  polyline { fill: none; stroke: #ffffff }
+  text { fill: #ffffff!important }
+  polyline { fill: none; stroke: #ffffff!important }
 }
 ]]></style>
 <text x="480" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="16.129032258064516" opacity="1">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ```
 //!
 #![cfg_attr(
-    feature = "std",
+    feature = "alloc",
     doc = r##"
 Format a number as an ordinal, allocating a new `String`:
 
@@ -37,9 +37,20 @@ assert_eq!(format!("{n}"), "12th");
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[allow(unused_imports)]
+#[cfg(feature = "alloc")]
+use alloc::{
+    format,
+    string::{String, ToString as _},
+};
 use core::fmt;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod number {
     use super::*;
     use core::ops::Deref;
@@ -104,7 +115,7 @@ mod number {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use number::Number;
 
 /// Format numbers as ordinals e.g., 1st, 12th, 21st, etc.
@@ -119,7 +130,7 @@ pub trait Ordinal: fmt::Display + Copy {
     /// assert_eq!(12, 12);
     /// assert_eq!(format!("{n}"), "12th");
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn to_number(self) -> Number<Self> {
         Number(self)
     }
@@ -132,7 +143,7 @@ pub trait Ordinal: fmt::Display + Copy {
     /// use ordinal_trait::Ordinal as _;
     /// assert_eq!(12.to_ordinal(), "12th");
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn to_ordinal(self) -> String {
         format!("{}{}", self, self.suffix())
     }
@@ -197,7 +208,7 @@ macro_rules! impl_abs {
 impl_abs!(unsigned u8 u16 u32 u64 u128 usize);
 impl_abs!(signed i8 i16 i32 i64 i128 isize);
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[test]
 fn test_fmt() {
     assert_eq!(0u8.to_ordinal(), "0th");


### PR DESCRIPTION
All the functionality I conditioned on `std` really only needs `alloc`. Following (mostly) what `serde` did, I defined both `std` (prior) and `alloc`, with `Number` et. al. conditioned on feature `alloc` instead.
